### PR TITLE
Issues with outcome signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "client_validator"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/client_validator/Cargo.toml
+++ b/crates/client_validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client_validator"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 repository = "https://github.com/tee8z/5day4cast"
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 repository = "https://github.com/tee8z/5day4cast"
 

--- a/crates/server/src/domain/competitions/coordinator.rs
+++ b/crates/server/src/domain/competitions/coordinator.rs
@@ -215,6 +215,7 @@ impl Coordinator {
                             if immediate_states.contains(&updated_competiton.get_state())
                                 && processed_states < MAX_CONSECUTIVE_STATES
                             {
+                                competition = updated_competiton;
                                 continue;
                             }
                         }


### PR DESCRIPTION
The root cause of the outcome transaction's broadcast failing had to do with us hard coding the funding transaction to a vout of 0 when signing the contract. By the time the funding transaction broadcasting the actual utxo ended up being different. The fix was to simply use the correct vout in the funding output when signing.

There is an additional small fix here in making sure the competition state progress correctly. Overall even though the code size is small, this was a battle to hunt down.