### PR TITLE
Fix payout 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-invoice"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3611,7 @@ dependencies = [
  "hex",
  "hyper 1.6.0",
  "itertools 0.14.0",
+ "lightning-invoice",
  "log",
  "maplit",
  "mime",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,6 +30,7 @@ itertools = "0.14.0"
 h2 = "0.4.5"
 hex = "0.4.3"
 hyper = "1.4.0"
+lightning-invoice = "0.33.2"
 log = "0.4.18"
 mime = "0.3.17"
 nostr-sdk = { version = "0.38.0" }

--- a/crates/server/migrations/competitions/20250803153207_create_schema.up.sql
+++ b/crates/server/migrations/competitions/20250803153207_create_schema.up.sql
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS entries (
     payout_preimage TEXT,                           -- Provided by user on payout, encrypted by coordinator_key
     sellback_broadcasted_at DATETIME,               -- When on chain sellback broadcasted by coordinator for cooperative lightning payout
     reclaimed_broadcasted_at DATETIME,              -- When on chain reclaim broadcasted by coordinator for uncooperative payout
-    signed_at DATETIME,                             -- When user completes musig signing
+    signed_at DATETIME                              -- When user completes musig signing
  );
 
 -- every lightning payout attempt will be recorded in the payouts table

--- a/crates/server/migrations/competitions/20250803153207_create_schema.up.sql
+++ b/crates/server/migrations/competitions/20250803153207_create_schema.up.sql
@@ -72,5 +72,6 @@ CREATE TABLE IF NOT EXISTS entries (
     paid_out_at DATETIME,                           -- When ticket have been paid out via lightning
     sellback_broadcasted_at DATETIME,               -- When on chain sellback broadcasted by coordinator for cooperative lightning payout
     reclaimed_broadcasted_at DATETIME,              -- When on chain reclaim broadcasted by coordinator for uncooperative payout
-    signed_at DATETIME                              -- When user completes musig signing
+    signed_at DATETIME,                             -- When user completes musig signing
+    payout_amount_sats INTEGER                      -- Amount paid out to user in sats via lightning
  );

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -153,6 +153,8 @@ pub struct LnSettings {
     pub tls_cert_path: Option<String>,
     /// Interval in seconds to check for new invoices
     pub invoice_watch_interval: u64,
+    /// Interval in seconds to check for new payouts
+    pub payout_watch_interval: u64,
 }
 
 impl Default for LnSettings {
@@ -162,6 +164,7 @@ impl Default for LnSettings {
             macaroon_file_path: String::from("./creds/admin.macaroon"),
             tls_cert_path: Some(String::from("./creds/tls.cert")),
             invoice_watch_interval: 5,
+            payout_watch_interval: 5,
         }
     }
 }

--- a/crates/server/src/domain/competitions/mod.rs
+++ b/crates/server/src/domain/competitions/mod.rs
@@ -55,6 +55,43 @@ pub enum EntryStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryPayout {
+    /// Client needs to provide a valid Uuidv7
+    pub id: Uuid,
+    pub entry_id: Uuid,
+    pub payout_status: PayoutStatus,
+    // User provide invoice to pay out user via lightning
+    pub payout_payment_request: String,
+    //  Amount paid out to user in sats via lightning
+    pub payout_amount_sats: u64,
+    #[serde(with = "time::serde::rfc3339")]
+    /// Time at which the payout initiated to the user
+    pub initiated_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    /// Time at which the payout completed
+    pub succeed_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    /// Time at which the payout failed
+    pub failed_at: Option<OffsetDateTime>,
+    /// Why the payout failed
+    pub error: PayoutError,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PayoutStatus {
+    Pending,
+    Succeeded,
+    Failed,
+}
+
+#[derive(thiserror::Error, Debug, Serialize, Clone, Deserialize)]
+pub enum PayoutError {
+    #[error("Failed to pay out user: {0}")]
+    FailedToPayOut(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserEntry {
     pub id: Uuid,
     /// The id used by the oracle to assoicate the event with this entry
@@ -82,8 +119,6 @@ pub struct UserEntry {
     pub ephemeral_privatekey: Option<String>,
     /// User provided preimage de-encrypted, only used during payout
     pub payout_preimage: Option<String>,
-    /// User provided lightning invoice, coordinator pays to user
-    pub payout_ln_invoice: Option<String>,
     pub public_nonces: Option<SigMap<PubNonce>>,
     /// User signed funding psbt
     pub funding_psbt_base64: Option<String>,
@@ -92,8 +127,6 @@ pub struct UserEntry {
     pub signed_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub paid_at: Option<OffsetDateTime>,
-    #[serde(with = "time::serde::rfc3339::option")]
-    pub paid_out_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub sellback_broadcasted_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339::option")]
@@ -129,13 +162,11 @@ impl FromRow<'_, SqliteRow> for UserEntry {
             entry_submission: parse_required_blob_json(row, "entry_submission")?,
             ephemeral_privatekey: row.get("ephemeral_privatekey"),
             payout_preimage: row.get("payout_preimage"),
-            payout_ln_invoice: row.get("payout_ln_invoice"),
             public_nonces: parse_optional_blob_json(row, "public_nonces")?,
             funding_psbt_base64: row.get("funding_psbt_base64"),
             partial_signatures: parse_optional_blob_json(row, "partial_signatures")?,
-            signed_at: parse_optional_sqlite_datetime(&row, "signed_at")?, // SQLite functio
+            signed_at: parse_optional_sqlite_datetime(&row, "signed_at")?,
             paid_at: parse_optional_sqlite_datetime(&row, "paid_at")?,
-            paid_out_at: parse_optional_datetime(&row, "paid_out_at")?,
             sellback_broadcasted_at: parse_optional_datetime(&row, "sellback_broadcasted_at")?,
             reclaimed_broadcasted_at: parse_optional_datetime(&row, "reclaimed_broadcasted_at")?,
         })
@@ -161,9 +192,7 @@ impl AddEntry {
             public_nonces: None,
             ephemeral_privatekey: None,
             payout_preimage: None,
-            payout_ln_invoice: None,
             paid_at: None,
-            paid_out_at: None,
             sellback_broadcasted_at: None,
             reclaimed_broadcasted_at: None,
         }
@@ -178,6 +207,10 @@ pub struct PayoutInfo {
     /// prior to paying us out via the ln invoice (the funds are still controlled by us,
     /// but now we're also giving access to the coordinator). If the coordinator is
     /// malicious we would need to broadcast the split transaction before them to get paid.
+    ///
+    /// Key point: The coordinator DOES NOT have unilateral control over the funds
+    /// (since we can still broadcast the split transaction before them)
+    ///
     /// The coordinator is incentivized to wait until all users have paid out as their reclaim/closing
     /// transaction becomes much cheaper. In a perfect world we would encrypt this preimage & ephemeral private key
     /// via AES with the ln_invoice's preimage and add a zkproof to allow the coordinator to

--- a/crates/server/src/domain/competitions/store.rs
+++ b/crates/server/src/domain/competitions/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use uuid::Uuid;
 
-use crate::{db::DBConnection, FinalSignatures};
+use crate::{db::DBConnection, domain::EntryPayout, FinalSignatures};
 
 use super::{Competition, EntryStatus, SearchBy, Ticket, UserEntry};
 
@@ -203,7 +203,7 @@ impl CompetitionStore {
         Ok(())
     }
 
-    pub async fn get_pending_payouts(&self) -> Result<Vec<PendingPayout>, sqlx::Error> {
+    pub async fn get_pending_payouts(&self) -> Result<Vec<EntryPayout>, sqlx::Error> {
         let rows = sqlx::query(
             "SELECT
                 id,
@@ -227,7 +227,7 @@ impl CompetitionStore {
             let payment_hash = crate::ln_client::extract_payment_hash_from_invoice(&ln_invoice)
                 .map_err(|e| sqlx::Error::Protocol(format!("Invalid invoice: {}", e)))?;
 
-            payouts.push(PendingPayout {
+            payouts.push(EntryPayout {
                 entry_id,
                 payment_hash,
                 ln_invoice,

--- a/crates/server/src/domain/invoices/mod.rs
+++ b/crates/server/src/domain/invoices/mod.rs
@@ -1,3 +1,26 @@
 mod invoice_watcher;
+mod payout_watcher;
 
 pub use invoice_watcher::InvoiceWatcher;
+pub use payout_watcher::PayoutWatcher;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PaymentLookupResponse {
+    pub status: PaymentStatus,
+    pub payment_error: Option<String>,
+    pub payment_preimage: Option<String>,
+    pub payment_hash: String,
+    pub value_sat: String,
+    pub fee_sat: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PaymentStatus {
+    Unknown,
+    InFlight,
+    Succeeded,
+    Failed,
+    Initiated,
+}

--- a/crates/server/src/domain/invoices/payout_watcher.rs
+++ b/crates/server/src/domain/invoices/payout_watcher.rs
@@ -1,0 +1,166 @@
+use anyhow::anyhow;
+use log::{debug, error, info, warn};
+use std::{sync::Arc, time::Duration};
+use time::OffsetDateTime;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+
+use crate::{domain::PaymentStatus, Coordinator, Ln};
+
+const MAX_PAYMENT_RETRIES: u32 = 3;
+const RETRY_DELAY_MS: u64 = 2000;
+
+pub struct PayoutWatcher {
+    coordinator: Arc<Coordinator>,
+    ln: Arc<dyn Ln>,
+    sync_interval: Duration,
+    cancel_token: CancellationToken,
+}
+
+impl PayoutWatcher {
+    pub fn new(
+        coordinator: Arc<Coordinator>,
+        ln: Arc<dyn Ln>,
+        cancel_token: CancellationToken,
+        sync_interval: Duration,
+    ) -> Self {
+        Self {
+            coordinator,
+            ln,
+            sync_interval,
+            cancel_token,
+        }
+    }
+
+    pub async fn watch(&self) -> Result<(), anyhow::Error> {
+        info!("Starting Payout watcher");
+
+        loop {
+            if self.cancel_token.is_cancelled() {
+                info!("Payout watcher received cancellation");
+                break;
+            }
+
+            match self.handle_pending_payouts().await {
+                Ok(_) => {
+                    debug!("Payout handling completed successfully");
+                }
+                Err(e) => {
+                    error!("Payout handling error: {}", e);
+                }
+            }
+
+            tokio::select! {
+                _ = sleep(self.sync_interval) => continue,
+                _ = self.cancel_token.cancelled() => {
+                    info!("Payout watcher cancelled during sleep");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_pending_payouts(&self) -> Result<(), anyhow::Error> {
+        let pending_payouts = self
+            .coordinator
+            .competition_store
+            .get_pending_payouts()
+            .await?;
+
+        debug!("Checking {} pending payouts", pending_payouts.len());
+
+        for payout in pending_payouts {
+            let payment_hash =
+                match crate::ln_client::extract_payment_hash_from_invoice(&payout.ln_invoice) {
+                    Ok(hash) => hash,
+                    Err(e) => {
+                        error!("Invalid lightning invoice, {}: {}", payout.entry_id, e);
+                        continue;
+                    }
+                };
+
+            match self.ln.lookup_payment(&payout.payment_hash).await {
+                Ok(payment) => {
+                    debug!(
+                        "Payout {}: payment status: {:?}",
+                        payout.entry_id, payment.status
+                    );
+
+                    match payment.status {
+                        PaymentStatus::Succeeded => {
+                            info!(
+                                "Payment succeeded for payout {}, marking as paid out",
+                                payout.entry_id
+                            );
+
+                            match self
+                                .coordinator
+                                .competition_store
+                                .mark_entry_paid_out(payout.entry_id, OffsetDateTime::now_utc())
+                                .await
+                            {
+                                Ok(_) => {
+                                    info!(
+                                        "Successfully marked entry {} as paid out",
+                                        payout.entry_id
+                                    );
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Failed to mark entry {} as paid out: {}",
+                                        payout.entry_id, e
+                                    );
+                                }
+                            }
+                        }
+                        PaymentStatus::Failed => {
+                            let error_msg = payment
+                                .payment_error
+                                .unwrap_or_else(|| "Payment failed".to_string());
+
+                            warn!(
+                                "Payment failed for payout {}: {}. Will resolve via onchain transaction.",
+                                payout.entry_id, error_msg
+                            );
+
+                            info!(
+                                "Payout {} will be resolved via onchain sellback or reclaim transaction",
+                                payout.entry_id
+                            );
+                        }
+                        PaymentStatus::InFlight => {
+                            debug!("Payment still in flight for payout {}", payout.entry_id);
+                        }
+                        PaymentStatus::Initiated => {
+                            debug!("Payment initiated for payout {}", payout.entry_id);
+                        }
+                        PaymentStatus::Unknown => {
+                            warn!("Payment status unknown for payout {}", payout.entry_id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(
+                        "Failed to lookup payment for payout {}: {}",
+                        payout.entry_id, e
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Data structure for pending payouts
+#[derive(Debug, Clone)]
+pub struct PendingPayout {
+    pub entry_id: uuid::Uuid,
+    pub payment_hash: String,
+    pub ln_invoice: String,
+    pub amount_sats: u64,
+    pub retry_count: u32,
+    pub initiated_at: OffsetDateTime,
+}

--- a/crates/server/tests/server/e2e_test.rs
+++ b/crates/server/tests/server/e2e_test.rs
@@ -103,6 +103,7 @@ impl TestContext {
             macaroon_file_path: String::from("./test_data/coord_ln/admin.macaroon"),
             tls_cert_path: Some(String::from("./test_data/coord_ln/tls.cert")),
             invoice_watch_interval: 10,
+            payout_watch_interval: 10,
         };
 
         let ln = LnClient::new(client, coordinator_ln).await?;
@@ -194,6 +195,7 @@ async fn test_two_person_competition_flow_with_real_lightning() -> Result<()> {
         macaroon_file_path: String::from("./test_data/alice_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/alice_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let alice_ln = LnClient::new(client.clone(), alice).await?;
     alice_ln.ping().await?;
@@ -202,6 +204,7 @@ async fn test_two_person_competition_flow_with_real_lightning() -> Result<()> {
         macaroon_file_path: String::from("./test_data/bob_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/bob_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let bob_ln = LnClient::new(client.clone(), bob).await?;
     bob_ln.ping().await?;
@@ -505,7 +508,7 @@ async fn test_two_person_competition_flow_with_real_lightning() -> Result<()> {
     let participant = ordered_participants[winning_entry_index as usize].clone();
 
     // Create a real invoice with the expected payout amount (should be entry fee)
-    let payout_amount = competition.event_submission.entry_fee as u64;
+    let payout_amount = competition.event_submission.total_competition_pool as u64;
     let ln_invoice = participant
         .ln_client
         .create_invoice(
@@ -659,6 +662,7 @@ async fn test_two_person_competition_flow_nobody_wins_with_real_lightning() -> R
         macaroon_file_path: String::from("./test_data/alice_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/alice_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let alice_ln = LnClient::new(client.clone(), alice).await?;
     alice_ln.ping().await?;
@@ -667,6 +671,7 @@ async fn test_two_person_competition_flow_nobody_wins_with_real_lightning() -> R
         macaroon_file_path: String::from("./test_data/bob_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/bob_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let bob_ln = LnClient::new(client.clone(), bob).await?;
     bob_ln.ping().await?;
@@ -963,7 +968,9 @@ async fn test_two_person_competition_flow_nobody_wins_with_real_lightning() -> R
     // All players should be able to claim a refund from this competition via lightning
     for participant in ordered_participants.iter() {
         // Create a real invoice with the expected payout amount
-        let payout_amount = competition.event_submission.total_competition_pool as u64; // Or calculate based on winner's share
+        let payout_amount = competition.event_submission.total_competition_pool as u64
+            / ordered_participants.len() as u64;
+
         let ln_invoice = participant
             .ln_client
             .create_invoice(
@@ -1114,6 +1121,7 @@ async fn test_two_person_competition_flow_contract_expires_with_real_lightning()
         macaroon_file_path: String::from("./test_data/alice_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/alice_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let alice_ln = LnClient::new(client.clone(), alice).await?;
     alice_ln.ping().await?;
@@ -1122,6 +1130,7 @@ async fn test_two_person_competition_flow_contract_expires_with_real_lightning()
         macaroon_file_path: String::from("./test_data/bob_ln/admin.macaroon"),
         tls_cert_path: Some(String::from("./test_data/bob_ln/tls.cert")),
         invoice_watch_interval: 10,
+        payout_watch_interval: 10,
     };
     let bob_ln = LnClient::new(client.clone(), bob).await?;
     bob_ln.ping().await?;

--- a/crates/server/tests/server/e2e_test.rs
+++ b/crates/server/tests/server/e2e_test.rs
@@ -256,10 +256,12 @@ async fn test_two_person_competition_flow_with_real_lightning() -> Result<()> {
             .request_ticket(nostr_bech32.clone(), competition.id, btc_pubkey)
             .await?;
         debug!("ticket: {:?}", ticket_response);
+
         // Actually pay the invoice using the user's lightning node
         user_ln_client
             .send_payment(
                 ticket_response.payment_request.clone(),
+                ticket_response.amount_sats,
                 300,  // timeout in seconds
                 1000, // fee limit in sats
             )
@@ -718,6 +720,7 @@ async fn test_two_person_competition_flow_nobody_wins_with_real_lightning() -> R
         user_ln_client
             .send_payment(
                 ticket_response.payment_request.clone(),
+                ticket_response.amount_sats,
                 300,  // timeout in seconds
                 1000, // fee limit in sats
             )
@@ -1173,6 +1176,7 @@ async fn test_two_person_competition_flow_contract_expires_with_real_lightning()
         user_ln_client
             .send_payment(
                 ticket_response.payment_request.clone(),
+                ticket_response.amount_sats,
                 300,  // timeout in seconds
                 1000, // fee limit in sats
             )

--- a/crates/server/tests/server/helpers.rs
+++ b/crates/server/tests/server/helpers.rs
@@ -113,6 +113,7 @@ mock! {
         async fn send_payment(
             &self,
             payout_payment_request: String,
+            amount_sats: u64,
             timeout_seconds: u64,
             fee_limit_sat: u64,
         ) -> Result<(), anyhow::Error>;

--- a/crates/server/tests/server/helpers.rs
+++ b/crates/server/tests/server/helpers.rs
@@ -90,6 +90,7 @@ mock! {
         async fn cancel_hold_invoice(&self, ticket_hash: String) -> Result<(), anyhow::Error>;
         async fn settle_hold_invoice(&self, ticket_preimage: String) -> Result<(), anyhow::Error>;
         async fn lookup_invoice(&self, r_hash: &str) -> Result<server::InvoiceLookupResponse, anyhow::Error>;
+        async fn lookup_payment(&self, r_hash: &str) -> Result<server::PaymentLookupResponse, anyhow::Error>;
         async fn add_hold_invoice(
             &self,
             value: u64,


### PR DESCRIPTION
Adds new logic to payout a user via lightning and watch to confirm the payout was successful. We then use this new data to determine what kind of broadcast we should be submitting to finish settling the competition. This should finally let us successful lightning invoices for player's winning tickets.