### PR TITLE
fix: correct state transaction for attestation check

### DIFF
--- a/crates/coordinator/migrations/competitions/20260129000000_add_awaiting_attestation_at.down.sql
+++ b/crates/coordinator/migrations/competitions/20260129000000_add_awaiting_attestation_at.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE competitions DROP COLUMN awaiting_attestation_at;

--- a/crates/coordinator/migrations/competitions/20260129000000_add_awaiting_attestation_at.up.sql
+++ b/crates/coordinator/migrations/competitions/20260129000000_add_awaiting_attestation_at.up.sql
@@ -1,0 +1,2 @@
+-- Add awaiting_attestation_at column to track when competition started waiting for oracle attestation
+ALTER TABLE competitions ADD COLUMN awaiting_attestation_at TEXT;

--- a/crates/coordinator/src/domain/competitions/states/funding.rs
+++ b/crates/coordinator/src/domain/competitions/states/funding.rs
@@ -170,7 +170,8 @@ impl FundingSettled {
     }
 
     /// Transition to AwaitingAttestation.
-    pub fn await_attestation(self) -> CompetitionStatus {
+    pub fn await_attestation(mut self) -> CompetitionStatus {
+        self.competition.awaiting_attestation_at = Some(OffsetDateTime::now_utc());
         CompetitionStatus::AwaitingAttestation(AwaitingAttestation::from_competition(
             self.competition,
         ))

--- a/crates/coordinator/src/domain/competitions/states/mod.rs
+++ b/crates/coordinator/src/domain/competitions/states/mod.rs
@@ -301,6 +301,9 @@ impl From<Competition> for CompetitionStatus {
             super::CompetitionState::FundingSettled => {
                 CompetitionStatus::FundingSettled(FundingSettled::from_competition(competition))
             }
+            super::CompetitionState::AwaitingAttestation => CompetitionStatus::AwaitingAttestation(
+                AwaitingAttestation::from_competition(competition),
+            ),
             super::CompetitionState::Attested => {
                 CompetitionStatus::Attested(Attested::from_competition(competition))
             }

--- a/crates/coordinator/src/domain/competitions/store.rs
+++ b/crates/coordinator/src/domain/competitions/store.rs
@@ -843,6 +843,11 @@ impl CompetitionStore {
                 .map(|ts| ts.format(&Rfc3339))
                 .transpose()
                 .map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
+            let awaiting_attestation_at = competition
+                .awaiting_attestation_at
+                .map(|ts| ts.format(&Rfc3339))
+                .transpose()
+                .map_err(|e| sqlx::Error::Encode(Box::new(e)))?;
             let expiry_broadcasted_at = competition
                 .expiry_broadcasted_at
                 .map(|ts| ts.format(&Rfc3339))
@@ -909,6 +914,7 @@ impl CompetitionStore {
                 funding_broadcasted_at,
                 funding_confirmed_at,
                 funding_settled_at,
+                awaiting_attestation_at,
                 expiry_broadcasted_at,
                 outcome_broadcasted_at,
                 delta_broadcasted_at,
@@ -944,6 +950,7 @@ impl CompetitionStore {
                     funding_broadcasted_at = ?,
                     funding_confirmed_at = ?,
                     funding_settled_at = ?,
+                    awaiting_attestation_at = ?,
                     expiry_broadcasted_at = ?,
                     outcome_broadcasted_at = ?,
                     delta_broadcasted_at = ?,
@@ -975,6 +982,7 @@ impl CompetitionStore {
                     funding_broadcasted_at,
                     funding_confirmed_at,
                     funding_settled_at,
+                    awaiting_attestation_at,
                     expiry_broadcasted_at,
                     outcome_broadcasted_at,
                     delta_broadcasted_at,
@@ -1007,6 +1015,7 @@ impl CompetitionStore {
                         .bind(funding_broadcasted_at)
                         .bind(funding_confirmed_at)
                         .bind(funding_settled_at)
+                        .bind(awaiting_attestation_at)
                         .bind(expiry_broadcasted_at)
                         .bind(outcome_broadcasted_at)
                         .bind(delta_broadcasted_at)
@@ -1071,6 +1080,7 @@ impl CompetitionStore {
                 funding_broadcasted_at as funding_broadcasted_at,
                 funding_confirmed_at as funding_confirmed_at,
                 funding_settled_at as funding_settled_at,
+                awaiting_attestation_at as awaiting_attestation_at,
                 invoices_settled_at as invoices_settled_at,
                 expiry_broadcasted_at as expiry_broadcasted_at,
                 outcome_broadcasted_at as outcome_broadcasted_at,
@@ -1111,6 +1121,7 @@ impl CompetitionStore {
                     funding_broadcasted_at,
                     funding_confirmed_at,
                     funding_settled_at,
+                    awaiting_attestation_at,
                     invoices_settled_at,
                     expiry_broadcasted_at,
                     outcome_broadcasted_at,
@@ -1149,6 +1160,7 @@ impl CompetitionStore {
                     funding_broadcasted_at,
                     funding_confirmed_at,
                     funding_settled_at,
+                    awaiting_attestation_at,
                     invoices_settled_at,
                     expiry_broadcasted_at,
                     outcome_broadcasted_at,
@@ -1215,6 +1227,7 @@ impl CompetitionStore {
                 funding_broadcasted_at as funding_broadcasted_at,
                 funding_confirmed_at as funding_confirmed_at,
                 funding_settled_at as funding_settled_at,
+                awaiting_attestation_at as awaiting_attestation_at,
                 invoices_settled_at as invoices_settled_at,
                 expiry_broadcasted_at as expiry_broadcasted_at,
                 outcome_broadcasted_at as outcome_broadcasted_at,
@@ -1252,6 +1265,7 @@ impl CompetitionStore {
                 funding_broadcasted_at,
                 funding_confirmed_at,
                 funding_settled_at,
+                awaiting_attestation_at,
                 invoices_settled_at,
                 expiry_broadcasted_at,
                 outcome_broadcasted_at,

--- a/crates/coordinator/src/templates/fragments/competition_row.rs
+++ b/crates/coordinator/src/templates/fragments/competition_row.rs
@@ -50,6 +50,7 @@ fn status_class(status: &str) -> &'static str {
     match status.to_lowercase().as_str() {
         "registration" => "tag is-success",
         "setup" | "live" => "tag is-warning",
+        "signing" => "tag is-warning",
         "completed" => "tag is-info",
         "failed" | "cancelled" => "tag is-danger",
         _ => "tag",


### PR DESCRIPTION
corrects issue where we never persist moving to the await attestation state and thus never actually ask the oracle if we have a signed event.